### PR TITLE
No need for OpenGL stuff in makefile lib list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lcaelina -lGL -lctru -lm
+LIBS	:= -lctru -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -259,8 +259,7 @@ int main()
     consoleInit(GFX_TOP, NULL);
     printf("CIAngel by cearp\n\n");
     printf("Press A to read data from SD and download CIA.\n\n");
-
-    bool refresh = true;
+    printf("Press START to exit.\n\n");
 
     while (aptMainLoop())
     {
@@ -277,6 +276,8 @@ int main()
             std::getline(input,titleId);
             std::getline(input,key);
             DownloadTitle(titleId, key, "/CIAngel");
+            
+            printf("Press START to exit.\n\n");
         }
 
         if (keys & KEY_START) break;


### PR DESCRIPTION
Currently build fails if you don't have machinamentum's OpenGL stuff installed, but it's not used, so remove the library references.
