### PR TITLE
Newline fix

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -251,26 +251,24 @@ std::istream& GetLine(std::istream& is, std::string& t)
     t.clear();
     std::istream::sentry se(is, true);
     std::streambuf* sb = is.rdbuf();
-    bool eolFound = false;
-    while (!eolFound) {
-        char c = (char) sb->sbumpc();
-        if (c == '\n') {
-            eolFound = true;
-        } else if (c == '\r') {
-            if (sb->sgetc() == '\n') {
+
+    for (;;) {
+        int c = sb->sbumpc();
+        switch (c) {
+            case '\n':
+              return is;
+            case '\r':
+              if (sb->sgetc() == '\n')
                 sb->sbumpc();
-            }
-            eolFound = true;
-        } else if (c == std::char_traits<char>::eof()) {
-            if (t.empty()) {
+              return is;
+            case  EOF:
+              if (t.empty())
                 is.setstate(std::ios::eofbit);
-            }
-            eolFound = true;
-        } else {
-            t += c;
+              return is;
+            default:
+              t += (char)c;
         }
     }
-    return is;
 }
 
 int main()


### PR DESCRIPTION
The previous code didn't work on (my) 3ds if there wasn't a newline at the end of the file (To the author's credit, it did work in Linux without issues). I directly copied the Stack Overflow answer it was based on which seems to work fine on 3ds.

Best guess as to why is using char instead of int for the storing of sbumpc (Char being unsigned, and EOF being -1). But I'm not seeing much reason to add the extra logic compared to the Stack Overflow answer either way.
