### PR TITLE
Fix issue where padding was being added with garbled data, leading to…

### DIFF
--- a/source/utils.c
+++ b/source/utils.c
@@ -116,6 +116,21 @@ void WriteBuffer(void *buffer, u64 size, u64 offset, FILE *output)
 	fwrite(buffer,size,1,output);
 } 
 
+void write_align_padding(FILE *output, size_t alignment)
+{
+	long int pos = ftell(output);
+	long int usedbytes = pos & (alignment - 1);
+	printf("Used bytes: %ld  Writing: %ld\n", usedbytes, (alignment - usedbytes));
+	if (usedbytes)
+	{
+		long int padbytes = (alignment - usedbytes);
+		char* pad = (char*)malloc(padbytes);
+		memset(pad, 0, padbytes);
+		fwrite(pad, padbytes, 1, output);
+		free(pad);
+	}
+}
+
 u64 GetFileSize_u64(char *filename)
 {
 	u64 size;

--- a/source/utils.h
+++ b/source/utils.h
@@ -29,6 +29,7 @@ void resolve_flag(unsigned char flag, unsigned char *flag_bool);
 void resolve_flag_u16(u16 flag, unsigned char *flag_bool);
 //IO Related
 void WriteBuffer(void *buffer, u64 size, u64 offset, FILE *output);
+void write_align_padding(FILE *output, size_t alignment);
 u64 GetFileSize_u64(char *filename);
 int TruncateFile_u64(char *filename, u64 filelen);
 int fseek_64(FILE *fp, u64 file_pos, int whence);


### PR DESCRIPTION
… differing hashes on every CIA build

Because apparently on desktops, fseek past end of file = 0x00, while on 3ds it means "I wonder what memory we can throw in here"
