### PR TITLE
Improve CIA generation speed

### DIFF
--- a/source/cia.h
+++ b/source/cia.h
@@ -125,7 +125,6 @@ typedef struct
 	u32 cert_size[2];
 	u16 content_count;
 	TMD_CONTENT_CHUNK_STRUCT *content_struct;
-	FILE **content;
 	
 	u16 *title_index;
 } __attribute__((__packed__)) 

--- a/source/types.h
+++ b/source/types.h
@@ -47,12 +47,3 @@ typedef enum
 	LE = 1
 } endianness_flag;
 
-typedef unsigned char   u8;
-typedef unsigned short  u16;
-typedef unsigned int    u32;
-typedef unsigned long long      u64;
-
-typedef signed char     s8;
-typedef signed short    s16;
-typedef signed int      s32;
-typedef signed long long        s64;

--- a/source/utils.c
+++ b/source/utils.c
@@ -121,7 +121,6 @@ void write_align_padding(FILE *output, size_t alignment)
 {
 	long int pos = ftell(output);
 	long int usedbytes = pos & (alignment - 1);
-	printf("Used bytes: %ld  Writing: %ld\n", usedbytes, (alignment - usedbytes));
 	if (usedbytes)
 	{
 		long int padbytes = (alignment - usedbytes);
@@ -216,7 +215,6 @@ Result DownloadFile(const char *url, FILE *os)
     u32 status;
     u32 bufSize = 0x100000;
     u32 readSize = 0;
-    printf("Downloading URL: %s\n", url);
     httpcOpenContext(&context, HTTPC_METHOD_GET, (char*)url, 1);
 
     ret = httpcBeginRequest(&context);

--- a/source/utils.c
+++ b/source/utils.c
@@ -116,6 +116,21 @@ void WriteBuffer(void *buffer, u64 size, u64 offset, FILE *output)
 	fwrite(buffer,size,1,output);
 } 
 
+void write_align_padding(FILE *output, size_t alignment)
+{
+	long int pos = ftell(output);
+	long int usedbytes = pos & (alignment - 1);
+	printf("Used bytes: %ld  Writing: %ld\n", usedbytes, (alignment - usedbytes));
+	if (usedbytes)
+	{
+		long int padbytes = (alignment - usedbytes);
+		char* pad = (char*)malloc(padbytes);
+		memset(pad, 0, padbytes);
+		fwrite(pad, padbytes, 1, output);
+		free(pad);
+	}
+}
+
 u64 GetFileSize_u64(char *filename)
 {
 	u64 size;

--- a/source/utils.h
+++ b/source/utils.h
@@ -16,6 +16,10 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with make_cdn_cia.  If not, see <http://www.gnu.org/licenses/>.
 **/
+#include <3ds.h>
+
+#define NUS_URL "http://ccs.cdn.c.shop.nintendowifi.net/ccs/download/"
+
 //MISC
 #ifdef __cplusplus
 extern "C" {
@@ -35,6 +39,7 @@ int TruncateFile_u64(char *filename, u64 filelen);
 int fseek_64(FILE *fp, u64 file_pos, int whence);
 int makedir(const char* dir);
 char *getcwdir(char *buffer,int maxlen);
+Result DownloadFile(const char *url, FILE *os);
 //Data Size conversion
 u16 u8_to_u16(u8 *value, u8 endianness);
 u32 u8_to_u32(u8 *value, u8 endianness);

--- a/source/utils.h
+++ b/source/utils.h
@@ -29,6 +29,7 @@ void resolve_flag(unsigned char flag, unsigned char *flag_bool);
 void resolve_flag_u16(u16 flag, unsigned char *flag_bool);
 //IO Related
 void WriteBuffer(void *buffer, u64 size, u64 offset, FILE *output);
+void write_align_padding(FILE *output, size_t alignment);
 u64 GetFileSize_u64(char *filename);
 int TruncateFile_u64(char *filename, u64 filelen);
 int fseek_64(FILE *fp, u64 file_pos, int whence);


### PR DESCRIPTION
Had to do a few odd things with this one due to the combination of C and C++ code in the project.
- Convert DownloadFile to C, since we need to access it from cia.c now
- Remove some typedefs that are defined in 3ds.h from types.h (Need 3ds.h in util.c now for download)
- Fixed a few warnings about sprintf's
- Move NUS_URL to a define since we need it in cia.c now
- Remove some debug output I accidentally left in my last PR
