### PR TITLE
Disable install mode when running as a 3dsx

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -270,6 +270,7 @@ int main(int argc, const char* argv[])
     gfxInitDefault();
     consoleInit(GFX_TOP, NULL);
 
+    /* Sadly svchax crashes too much, so only allow install mode when running as a CIA
     // Trigger svchax so we can install CIAs
     if(argc > 0) {
         svchax_init(true);
@@ -277,6 +278,13 @@ int main(int argc, const char* argv[])
             bSvcHaxAvailable = false;
             printf("Failed to acquire kernel access. Install mode disabled.\n");
         }
+    }
+    */
+    
+    // argc is 0 when running as a CIA, and 1 when running as a 3dsx
+    if (argc > 0)
+    {
+        bSvcHaxAvailable = false;
     }
 
     u32 *soc_sharedmem, soc_sharedmem_size = 0x100000;


### PR DESCRIPTION
This commit disables triggering svchax, which should fix the crashing issue with the 3dsx version. It still allows installing when running as a CIA though.

Your call on whether to merge this one, just figured I'd throw the code up before I have to shut off my laptop :)
