### PR TITLE
fix menu_main footer buffer overflow on exit

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -564,7 +564,7 @@ void menu_main()
         "About CIAngel",
         "Exit"
     };
-    char footer[31];
+    char footer[42];
 
     while (true)
     {


### PR DESCRIPTION
Enabling "Install mode", footer becomes larger than buffer, leading to a full system reboot on "Exit".
