### PR TITLE
Download JSON from 3ds.nfshost, instead of using Wings.json

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -36,6 +36,7 @@
 static const u16 top = 0x140;
 static bool bSvcHaxAvailable = true;
 static bool bExit = false;
+int sourceDataType;
 Json::Value sourceData;
 enum install_modes {make_cia, install_direct, install_ticket};
 install_modes selected_mode = make_cia;
@@ -561,11 +562,23 @@ void action_search()
                 game_item item;
                 item.ld = ld;
                 item.index = i;
-                item.titleid = sourceData[i]["titleid"].asString();
-                item.titlekey = sourceData[i]["enckey"].asString();
-                item.name = sourceData[i]["name"].asString();
-                item.region = sourceData[i]["region"].asString();
-                item.code = sourceData[i]["code"].asString();
+
+                switch(sourceDataType) {
+                case JSON_TYPE_WINGS:
+                  item.titleid = sourceData[i]["titleid"].asString();
+                  item.titlekey = sourceData[i]["enckey"].asString();
+                  item.name = sourceData[i]["name"].asString();
+                  item.region = sourceData[i]["region"].asString();
+                  item.code = sourceData[i]["code"].asString();
+                  break;
+                case JSON_TYPE_ONLINE:
+                  item.titleid = sourceData[i]["titleID"].asString();
+                  item.titlekey = sourceData[i]["encTitleKey"].asString();
+                  item.name = sourceData[i]["name"].asString();
+                  item.region = sourceData[i]["region"].asString();
+                  item.code = sourceData[i]["serial"].asString();
+                  break;
+                }
 
                 display_output.push_back(item);
             }
@@ -774,6 +787,10 @@ void action_exit()
 {
     bExit = true;
 }
+void action_download()
+{
+  download_JSON();
+}
 
 // Main menu keypress callback
 bool menu_main_keypress(int selected, u32 key, void*)
@@ -796,9 +813,12 @@ bool menu_main_keypress(int selected, u32 key, void*)
                 action_input_txt();
             break;
             case 4:
-                action_about();
+                action_download();
             break;
             case 5:
+                action_about();
+            break;
+            case 6:
                 action_exit();
             break;
         }
@@ -828,8 +848,9 @@ void menu_main()
         "Process download queue",
         "Enter a title key/ID pair",
         "Fetch title key/ID from input.txt",
+        "Download wings.json",
         "About CIAngel",
-        "Exit"
+        "Exit",
     };
     char footer[50];
 
@@ -900,6 +921,13 @@ int main(int argc, const char* argv[])
     Json::Value obj;
     reader.parse(ifs, obj);
     sourceData = obj; // array of characters
+    
+    if(sourceData[0]["titleID"].isString()) {
+      sourceDataType = JSON_TYPE_WINGS;
+    } else if (sourceData[0]["titleid"].isString()) {
+      sourceDataType = JSON_TYPE_ONLINE;
+    }
+
 
     menu_main();
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -212,7 +212,7 @@ void InstallTicket(std::string FullPath)
     AM_InstallTicketBegin(&hTik);
     std::string curr = get_file_contents(FullPath.c_str());
     FSFILE_Write(hTik, &writtenbyte, 0, curr.c_str(), 0x100000, 0);
-    AM_InstallTicketFinalize(hTik);
+    AM_InstallTicketFinish(hTik);
     printf("Ticket Installed.");
     //delete temp ticket, ticket folder still exists... ugly. later stream directly to the handle
     remove(FullPath.c_str());

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -436,6 +436,22 @@ std::string ToHex(const std::string& s)
     return ret.str();
 }
 
+void load_JSON_data() 
+{
+    printf("loading wings.json...\n");
+    std::ifstream ifs("/CIAngel/wings.json");
+    Json::Reader reader;
+    Json::Value obj;
+    reader.parse(ifs, obj);
+    sourceData = obj; // array of characters
+    
+    if(sourceData[0]["titleID"].isString()) {
+      sourceDataType = JSON_TYPE_WINGS;
+    } else if (sourceData[0]["titleid"].isString()) {
+      sourceDataType = JSON_TYPE_ONLINE;
+    }
+}
+
 int levenshtein_distance(const std::string &s1, const std::string &s2)
 {
     // To change the type this function manipulates and returns, change
@@ -787,9 +803,11 @@ void action_exit()
 {
     bExit = true;
 }
+
 void action_download()
 {
   download_JSON();
+  load_JSON_data();
 }
 
 // Main menu keypress callback
@@ -915,20 +933,8 @@ int main(int argc, const char* argv[])
     init_menu(GFX_TOP);
     // Set up the reading of json
     check_JSON();
-    printf("loading wings.json...\n");
-    std::ifstream ifs("/CIAngel/wings.json");
-    Json::Reader reader;
-    Json::Value obj;
-    reader.parse(ifs, obj);
-    sourceData = obj; // array of characters
+    load_JSON_data();
     
-    if(sourceData[0]["titleID"].isString()) {
-      sourceDataType = JSON_TYPE_WINGS;
-    } else if (sourceData[0]["titleid"].isString()) {
-      sourceDataType = JSON_TYPE_ONLINE;
-    }
-
-
     menu_main();
 
     if (bSvcHaxAvailable)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -446,9 +446,9 @@ void load_JSON_data()
     sourceData = obj; // array of characters
     
     if(sourceData[0]["titleID"].isString()) {
-      sourceDataType = JSON_TYPE_WINGS;
-    } else if (sourceData[0]["titleid"].isString()) {
       sourceDataType = JSON_TYPE_ONLINE;
+    } else if (sourceData[0]["titleid"].isString()) {
+      sourceDataType = JSON_TYPE_WINGS;
     }
 }
 

--- a/source/utils.c
+++ b/source/utils.c
@@ -544,10 +544,35 @@ void clear_screen(gfxScreen_t screen)
     gspWaitForVBlank();
 }
 
+bool download_JSON() {
+  printf("Attempting to download JSON...\n");
+  remove("/CIAngel/wings.json.tmp");
+  FILE *oh = fopen("/CIAngel/wings.json.tmp", "wb");
+  if (oh) {
+    Result res = DownloadFile(JSON_URL, oh, false);
+    fclose(oh);
+    if (res != 0) {
+      printf("Failed to download JSON");
+    } else {
+      remove("/CIAngel/wings.json");
+      rename("/CIAngel/wings.json.tmp", "/CIAngel/wings.json");
+      return true;
+    }
+  }
+  return false;
+}
+
 bool check_JSON() {
     if(!FileExists ("/CIAngel/wings.json")) {
-        printf("No wings.json\n Don't expect the search to work\n");
-        wait_key_specific("\nPress A to return.\n", KEY_A);
+        printf("No wings.json\n");
+
+        printf("\nPress A to Download, or any other key to return.\n");
+        u32 keys = wait_key();
+        
+        if (keys & KEY_A) {
+          return download_JSON();
+        }
+        printf("\nDon't expect search to work\n");
         return false;
     }
     return true;

--- a/source/utils.c
+++ b/source/utils.c
@@ -545,20 +545,23 @@ void clear_screen(gfxScreen_t screen)
 }
 
 bool download_JSON() {
-  printf("Attempting to download JSON...\n");
+  printf("\nAttempting to download JSON...\n");
+  
   remove("/CIAngel/wings.json.tmp");
   FILE *oh = fopen("/CIAngel/wings.json.tmp", "wb");
+  
   if (oh) {
     Result res = DownloadFile(JSON_URL, oh, false);
+    int size = ftell(oh);
     fclose(oh);
-    if (res != 0) {
-      printf("Failed to download JSON");
-    } else {
+    if (res == 0 && size >= 0) {
       remove("/CIAngel/wings.json");
       rename("/CIAngel/wings.json.tmp", "/CIAngel/wings.json");
       return true;
     }
   }
+  
+  printf("Failed to download JSON");
   return false;
 }
 

--- a/source/utils.h
+++ b/source/utils.h
@@ -19,6 +19,10 @@ along with make_cdn_cia.  If not, see <http://www.gnu.org/licenses/>.
 #include <3ds.h>
 
 #define NUS_URL "http://ccs.cdn.c.shop.nintendowifi.net/ccs/download/"
+#define JSON_URL "http://3ds.nfshost.com/json"
+
+#define JSON_TYPE_WINGS 1
+#define JSON_TYPE_ONLINE 2
 
 //MISC
 #ifdef __cplusplus
@@ -31,6 +35,7 @@ void u8_hex_print_le(u8 *array, int len);
 u32 align_value(u32 value, u32 alignment);
 void resolve_flag(unsigned char flag, unsigned char *flag_bool);
 void resolve_flag_u16(u16 flag, unsigned char *flag_bool);
+bool download_JSON();
 bool check_JSON();
 //IO Related
 void PrintProgress(u32 nSize, u32 nCurrent);


### PR DESCRIPTION
The only differences in the JSON files are the key names, I see no reason not to just use the source of the data in the first place. In order to allow easy updating of the file, download_JSON() has been added to the menu. 

In the means of backwards compatibility, I added support to still read from the wings.json format, although another way of dealing with this would be to detect the old file still in place, and remove and download the new file in that event.

Also, work in some smart reloading features, to keep things fresh
