### PR TITLE
If wings are stale, offer to update them on init

### DIFF
--- a/source/utils.c
+++ b/source/utils.c
@@ -566,17 +566,37 @@ bool download_JSON() {
 }
 
 bool check_JSON() {
-    if(!FileExists ("/CIAngel/wings.json")) {
-        printf("No wings.json\n");
+    struct stat filestats;
+    int ret = stat("/CIAngel/wings.json", &filestats);
+    time_t curtime = time(NULL);
 
-        printf("\nPress A to Download, or any other key to return.\n");
+    if (ret == 0) {
+      double age_seconds = difftime(filestats.st_mtime, curtime);
+      double age_days = age_seconds / (60 * 60 * 24);
+
+      if (age_seconds > JSON_UPDATE_INTERVAL_IN_SECONDS) {
+        printf("Your wings.json is %d days old\n\n", (int)age_days);
+        printf("Press A to update, or any other key to skip.\n");
+
         u32 keys = wait_key();
-        
+
         if (keys & KEY_A) {
           return download_JSON();
         }
-        printf("\nDon't expect search to work\n");
-        return false;
+        return true;
+      }
+    } else {
+      printf("No wings.json\n");
+
+      printf("\nPress A to Download, or any other key to return.\n");
+      u32 keys = wait_key();
+      
+      if (keys & KEY_A) {
+        return download_JSON();
+      }
+      printf("\nDon't expect search to work\n");
+      return false;
     }
+
     return true;
 }

--- a/source/utils.c
+++ b/source/utils.c
@@ -571,7 +571,9 @@ bool check_JSON() {
     time_t curtime = time(NULL);
 
     if (ret == 0) {
-      double age_seconds = difftime(filestats.st_mtime, curtime);
+      u64 mtime;
+      sdmc_getmtime("/CIAngel/wings.json", &mtime);
+      double age_seconds = difftime(curtime, mtime);
       double age_days = age_seconds / (60 * 60 * 24);
 
       if (age_seconds > JSON_UPDATE_INTERVAL_IN_SECONDS) {
@@ -600,3 +602,4 @@ bool check_JSON() {
 
     return true;
 }
+

--- a/source/utils.h
+++ b/source/utils.h
@@ -21,6 +21,9 @@ along with make_cdn_cia.  If not, see <http://www.gnu.org/licenses/>.
 #define NUS_URL "http://ccs.cdn.c.shop.nintendowifi.net/ccs/download/"
 #define JSON_URL "http://3ds.nfshost.com/json"
 
+// Check for updates every 3 days automatically?
+#define JSON_UPDATE_INTERVAL_IN_SECONDS (60 * 60 * 24 * 3)
+
 #define JSON_TYPE_WINGS 1
 #define JSON_TYPE_ONLINE 2
 


### PR DESCRIPTION
utils.h defines JSON_UPDATE_INTERVAL_IN_SECONDS, which is set
to 3 days at the moment. We can tweak this if we think its
too short or long, but I like this.

Currently untested, I don't have my 3ds on me to try with

The easiest way to test this, would be to change the modified time of your wings.json to a few days ago, and then launch and see if it complains of a stale file and offers to download them.

If no one gets to this, I'll do it when I get home tonight
