### PR TITLE
Fix build with latest libctru

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -297,7 +297,7 @@ Result DownloadTitle(std::string titleId, std::string encTitleKey, std::string t
                 httpcSetSSLOpt(&context, SSLCOPT_DisableVerify);
 
                 u32 responseCode = 0;
-                if(R_SUCCEEDED(res = httpcBeginRequest(&context)) && R_SUCCEEDED(res = httpcGetResponseStatusCode(&context, &responseCode, 0))) {
+                if(R_SUCCEEDED(res = httpcBeginRequest(&context)) && R_SUCCEEDED(res = httpcGetResponseStatusCode(&context, &responseCode))) {
                     if(responseCode == 200) {
                         u32 pos = 0;
                         u32 bytesRead = 0;

--- a/source/utils.cpp
+++ b/source/utils.cpp
@@ -322,7 +322,7 @@ Result DownloadFile_Internal(const char *url, void *out, bool bProgress,
     ret = httpcBeginRequest(&context);
     if (ret != 0) goto _out;
 
-    ret = httpcGetResponseStatusCode(&context, &status, 0);
+    ret = httpcGetResponseStatusCode(&context, &status);
     if (ret != 0) goto _out;
 
     if (status != 200)


### PR DESCRIPTION
The third argument for httpcGetResponseStatusCode was removed, which caused build failures.
Seems like that argument was unused anyway, so I removed it from all calls of that function.